### PR TITLE
Update 翻译脚本.txt

### DIFF
--- a/翻译脚本.txt
+++ b/翻译脚本.txt
@@ -2122,6 +2122,16 @@ e._v("Tray Proxy Groups Style")=e._v("托盘代理组样式")
 "Submenu","Hidden"="子菜单","隐藏"
 #0.19.19-end
 
+#0.19.22
+attrs:{type:"text",placeholder:"search"}=attrs:{type:"text",placeholder:"筛选"}
+attrs:{hint:"terminal"}=attrs:{hint:"终端"}
+"Network Interfaces"="网络接口"
+"Network interfaces"="网络接口"
+[e._v("Address:")]=[e._v("地址:")]
+[e._v("Netmask:")]=[e._v("子网掩码:")]
+"Process Path"="进程路径"
+#0.19.22-end
+
 #0.19.23
 "Show Process If Present"="显示进程(如果存在)"
 #0.19.23-end


### PR DESCRIPTION
### 说明

因为大佬把之前我在 `0.19.22` 时的 pr(#54) 关掉了，但最新的汉化包里面依旧没有处理一些在 `0.19.22` 版本新增或者改动的字符串，所以重新提个 pr，考虑到大佬不一定有时间校对，随便标注一下位置吧。

### 改动

---

```
attrs:{type:"text",placeholder:"search"}=attrs:{type:"text",placeholder:"筛选"}
```

是在"连接"页面搜索框里的占位符(因为 64cea04 注释掉了会导致出错的 `"search"="筛选"`，所以之前关于此处的汉化丢失了)：

![search](https://gcore.jsdelivr.net/gh/LightAPIs/PicGoImg@master/img/202207021225543.jpg)

---

```
attrs:{hint:"terminal"}=attrs:{hint:"终端"}
```

是在"常规"页面终端图标的悬浮提示：

![terminal](https://gcore.jsdelivr.net/gh/LightAPIs/PicGoImg@master/img/202207021233040.jpg)

---

```
"Network Interfaces"="网络接口"
"Network interfaces"="网络接口"
[e._v("Address:")]=[e._v("地址:")]
[e._v("Netmask:")]=[e._v("子网掩码:")]
```

是新增的网络接口面板：

![Network_interfaces](https://gcore.jsdelivr.net/gh/LightAPIs/PicGoImg@master/img/202207021235183.jpg)

![Network_Interfaces](https://gcore.jsdelivr.net/gh/LightAPIs/PicGoImg@master/img/202207021236688.jpg)

---

```
"Process Path"="进程路径"
```

是每个连接的连接信息中新增的条目：

![process](https://gcore.jsdelivr.net/gh/LightAPIs/PicGoImg@master/img/202207021239768.jpg)

---

OK，就这些了，❤。