### PR TITLE
修改"Allow LAN"的翻译

### DIFF
--- a/翻译脚本.txt
+++ b/翻译脚本.txt
@@ -795,8 +795,8 @@ Change Mixed Port=变更 Mixed 端口
 'Restarting core...'='正在重启内核...'
 "CMD with proxy"="CMD 代理"
 'CMD with proxy'='CMD 代理'
-"Allow LAN"="允许局域网连接"
-'Allow LAN'='允许局域网连接'
+"Allow LAN"="允许局域网代理"
+'Allow LAN'='允许局域网代理'
 "Core Version"="Clash 核心版本"
 'Core Version'='Clash 核心版本'
 "Clash Core"="Clash 核心"
@@ -2161,7 +2161,7 @@ e.failedProvidersCount?"":"s"=e.failedProvidersCount?"":""
 
 #0.19.27
 "network interfaces"="网络接口"
-"add firewall rules(for Allow LAN and system stack)"="添加防火墙规则(用于允许局域网连接和系统栈)"
+"add firewall rules(for Allow LAN and system stack)"="添加防火墙规则(用于允许局域网代理和系统栈)"
 #0.19.27-end
 
 #0.19.28
@@ -2510,5 +2510,5 @@ title:"Destination Port"=title:"目标端口"
 "\n          Bind: "="\n          绑定: "
 "New Bind Address"="新的绑定地址"
 "Change Bind Address"="更改绑定地址"
-"Allow LAN will only bind to address you set, * means all interfaces"="允许局域网连接将只绑定到您设置的地址，* 表示所有接口"
+"Allow LAN will only bind to address you set, * means all interfaces"="允许局域网代理将只绑定到您设置的地址，* 表示所有接口"
 #0.20.32-end


### PR DESCRIPTION
原先的"允许局域网连接"在软件其他功能引用说明里会有些许的歧义，但是用更完整的描述如："允许来自局域网的连接"又太长了。感觉应该翻译本身功能的作用："允许局域网代理"，这样也更直观。