### PR TITLE
关于增强托盘内容里会出现重叠遮挡的情况

### DIFF
--- a/翻译脚本.txt
+++ b/翻译脚本.txt
@@ -1029,20 +1029,20 @@ t.chains[0]=t.chains[0]==="DIRECT"?"直连":t.chains[0]
 e._s(e.mode)=("global"==e._s(e.mode)?"全局":"rule"==e._s(e.mode)?"规则":"direct"==e._s(e.mode)?"直连":"script"==e._s(e.mode)?"脚本":e._s(e.mode))
 e._s(e.logLevel)=("silent"==e._s(e.logLevel)?"静默":"error"==e._s(e.logLevel)?"错误":"warning"==e._s(e.logLevel)?"警告":'warn'==e._s(e.logLevel)?"警告":"info"==e._s(e.logLevel)?"信息":"debug"==e._s(e.logLevel)?"调试":e._s(e.logLevel))
 ###v0.15.3
-e.mode[0].toUpperCase()=("G"==e.mode[0].toUpperCase()?"全局":"R"==e.mode[0].toUpperCase()?"规则":"D"==e.mode[0].toUpperCase()?"直连":"S"==e.mode[0].toUpperCase()?"脚本":e.mode[0].toUpperCase())
+#e.mode[0].toUpperCase()=("G"==e.mode[0].toUpperCase()?"全局":"R"==e.mode[0].toUpperCase()?"规则":"D"==e.mode[0].toUpperCase()?"直连":"S"==e.mode[0].toUpperCase()?"脚本":e.mode[0].toUpperCase())
 
 ## 增强托盘自定义文字位置
-fillText(c,300,50)=fillText(c,320,50)
+#fillText(c,300,50)=fillText(c,320,50)
 
 ## 0 B/s末尾位置
-280+(=310+(
+#280+(=310+(
 
 #20210910
 
-,270,=,300,
-93,3=123,3
-lineTo(100=lineTo(130
-107,3=137,3
+#,270,=,300,
+#93,3=123,3
+#lineTo(100=lineTo(130
+#107,3=137,3
 
 
 ###v0.15.5


### PR DESCRIPTION
[这里](https://github.com/BoyceLig/Clash_Chinese_Patch/blob/5049826fe6435af296aeba845a46ced986a48e99/%E7%BF%BB%E8%AF%91%E8%84%9A%E6%9C%AC.txt#L1032C23-L1032C23)的汉化会导致增强托盘出现重叠遮挡的现象：

![rule](https://github.com/BoyceLig/Clash_Chinese_Patch/assets/47911535/d8e28077-8510-4c99-85b2-080114789ea3)

另外就算不遮挡，一般情况下也会因为宽度不足无法完整显示，例如在 macOS 的工具栏上：
![macOS](https://github.com/BoyceLig/Clash_Chinese_Patch/assets/47911535/841d1694-5094-436b-9157-419b759db531)

所以应该还是维持原样好些。
